### PR TITLE
Simple cosmetic syntactical error

### DIFF
--- a/wt_apps.py
+++ b/wt_apps.py
@@ -57,7 +57,7 @@ class WT_Apps(object):
     # class members
     __privacy_init = False
     __Privacy2Levels = {}
-    __LevelsPrivacy = {}
+    __Levels2Privacy = {}
 
     @classmethod
     def Privacy2Level(cls, privacy):

--- a/wt_apps.py
+++ b/wt_apps.py
@@ -7,13 +7,15 @@ wt_apps.py provides an interface to the WikiTree APPS API.
 This code is designed to work with
 Python 2.7
 and
-Python 3.4, 3.5 and 3.6.
+Python 3.4, 3.5, 3.6 and 3.7.
 
 It has been tested
 on cygwin
     with python2 2.7.13 and python3 3.6.1
 and on Windows 7
     with python 2.7.13, and python 3.6.1
+and on Ubuntu Linux 18.04LTS
+    with python 3.7
 """
 
 from __future__ import print_function, unicode_literals


### PR DESCRIPTION
I spotted that there was a class member for WT_Apps named <code>__LevelsPrivacy</code> but all code used <code>__Levels2Privacy</code>.  A closer inspection discovered that the class initialisation was creating the correct class member.

Although this is basically a cosmetic error, it is nevertheless syntactically incorrect.