### PR TITLE
update wikitree API url

### DIFF
--- a/wt_apps.py
+++ b/wt_apps.py
@@ -50,7 +50,7 @@ class WT_Apps(object):
     """WikiTree Apps interface
     """
 
-    _url = "https://apps.wikitree.com/api.php"
+    _url = "https://api.wikitree.com/api.php"
     _default_format = "json"
     _format = _default_format
     _session = None


### PR DESCRIPTION
The wikitree API url changed around the end of August
2020. With the new url, pywikitree continues to function
as ususal.